### PR TITLE
Fix EPERM error from clean on Windows 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -488,6 +488,7 @@ class EasyDl extends EventEmitter {
           this._report(id);
         })
         .on("error", (err) => {
+          dest.destroy();
           if (this._destroyed) return;
           this.emit("error", err);
         })


### PR DESCRIPTION
### Problem
When calling `start` on a download, then `destroy`, and then `clean` on Windows. The `PART` files (in progress chunk downloads) are sometimes not released by EasyDL, giving an `EPERM` error and failing to delete the files until the process running EasyDL is terminated.

### Diagnosis
When calling `destroy` on `EasyDl`, the in progress requests fail with `abort` and sometimes `socket hang up` errors [here](https://github.com/andresusanto/easydl/blob/e3e14c3c732fe0be17a2d6e6fe1d1dc7785f49ec/src/index.ts#L490C9-L493C11)

```
        .on("error", (err) => {
          if (this._destroyed) return;
          this.emit("error", err);
        })
```

When the request fails with `abort`, [`"close"` is called on the request](https://github.com/andresusanto/easydl/blob/e3e14c3c732fe0be17a2d6e6fe1d1dc7785f49ec/src/request.ts#L118), [wait resolves](https://github.com/andresusanto/easydl/blob/e3e14c3c732fe0be17a2d6e6fe1d1dc7785f49ec/src/index.ts#L495), and [the write stream is destroyed](https://github.com/andresusanto/easydl/blob/e3e14c3c732fe0be17a2d6e6fe1d1dc7785f49ec/src/index.ts#L497)

When the request fails with `socket hang up`, `"close"` is not called and the write stream is never destroyed. This causes an EPERM issue during the `fs.unlink` call in `clean` which only marks the files for deletion until they are released (reference: https://github.com/nodejs/node-v0.x-archive/issues/7164). Note that changing `fs.unlink` to `fs.rm` throws an error, so the fundamental issue of releasing the file from the process still needs to be addressed.

### Solution
By destroying the write stream in the request error handler, EasyDL releases the `PART` file when a request fails, which solves the socket hang up issue.

I can't think of a reason we would want to keep the write stream open if a chunk http request throws while downloading, so this  can apply to all request errors.

### Testing
To test this, `start` a download on windows, call `destroy`, call `clean`, and then leave the process open. You will see that the files are released and deleted even though the process is still running.